### PR TITLE
deployment: persist ssl certificate

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -14,3 +14,11 @@ services:
       - "443:443/udp"
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+    external: true
+    name: outmatched_api_caddy_data
+  caddy_config:


### PR DESCRIPTION
Persist SSL certificate outside docker image. This will prevent hitting Let's Encrypt rate limits.