### PR TITLE
Made home screen button appear above reaction

### DIFF
--- a/client/src/components/player-screen/tournament-win/TournamentWin.tsx
+++ b/client/src/components/player-screen/tournament-win/TournamentWin.tsx
@@ -40,7 +40,7 @@ const TournamentWin = ({ playerName }: TournamentWinScreenProps) => {
           className="md:w-60 hidden  md:visible"
         />
       </div>
-      <div className="absolute inset-x-0 bottom-10">
+      <div className="absolute inset-x-0 bottom-10 z-60">
         <button
           className="text-white bg-primary text-3xl w-80 md:w-96 lg:w-122 font-bold rounded-xl h-full border-white"
           onClick={() => navigate("/")}


### PR DESCRIPTION
Made home screen button appear above the reaction overlay, allowing spectators to return to the home screen after the tournament ended. 