### PR TITLE
Fix/join game style

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -109,12 +109,14 @@ body {
   display: inline-block;
 }
 
-.large-input, .large-btn {
+.large-input,
+.large-btn {
   max-width: 415px;
 }
 
 @media screen and (max-width: 700px) {
-  .large-input, .large-btn {
+  .large-input,
+  .large-btn {
     width: 90% !important;
   }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -108,3 +108,13 @@ body {
   text-align: center;
   display: inline-block;
 }
+
+.large-input, .large-btn {
+  max-width: 415px;
+}
+
+@media screen and (max-width: 700px) {
+  .large-input, .large-btn {
+    width: 90% !important;
+  }
+}

--- a/client/src/components/buttons/FormButton.tsx
+++ b/client/src/components/buttons/FormButton.tsx
@@ -2,12 +2,13 @@ type FormButtonInputs = {
   text: string;
   loading: boolean;
   callback: () => void;
+  additionalClass?: string;
 };
 
-const FormButtonComponent = ({ text, loading, callback }: FormButtonInputs) => {
+const FormButtonComponent = ({ text, loading, callback, additionalClass }: FormButtonInputs) => {
   return (
     <button
-      className="h-12 mt-8 text-white bg-primary text-2xl font-bold w-1/3 rounded-xl"
+      className={`h-12 mt-8 text-white bg-primary text-2xl font-bold w-1/3 rounded-xl ${additionalClass ?? ""}`}
       onClick={callback}
       disabled={loading}
     >

--- a/client/src/components/buttons/FormButton.tsx
+++ b/client/src/components/buttons/FormButton.tsx
@@ -5,7 +5,12 @@ type FormButtonInputs = {
   additionalClass?: string;
 };
 
-const FormButtonComponent = ({ text, loading, callback, additionalClass }: FormButtonInputs) => {
+const FormButtonComponent = ({
+  text,
+  loading,
+  callback,
+  additionalClass,
+}: FormButtonInputs) => {
   return (
     <button
       className={`py-2 px-5 mt-8 text-white bg-primary text-2xl font-bold w-1/3 rounded-xl ${additionalClass ?? ""}`}

--- a/client/src/components/buttons/FormButton.tsx
+++ b/client/src/components/buttons/FormButton.tsx
@@ -8,7 +8,7 @@ type FormButtonInputs = {
 const FormButtonComponent = ({ text, loading, callback, additionalClass }: FormButtonInputs) => {
   return (
     <button
-      className={`h-12 mt-8 text-white bg-primary text-2xl font-bold w-1/3 rounded-xl ${additionalClass ?? ""}`}
+      className={`py-2 px-5 mt-8 text-white bg-primary text-2xl font-bold w-1/3 rounded-xl ${additionalClass ?? ""}`}
       onClick={callback}
       disabled={loading}
     >

--- a/client/src/components/inputs/InputComponent.tsx
+++ b/client/src/components/inputs/InputComponent.tsx
@@ -3,12 +3,13 @@ type InputComponentProps = {
   callback: (value: string) => void;
   placeholder: string;
   disabled: boolean;
+  additionalClass?: string;
 };
 
 const InputComponent = ({ callback, ...props }: InputComponentProps) => {
   return (
     <input
-      className="bg-primary-dark rounded-xl w-1/3 h-10 mt-4 border-2 pl-2 focus:outline-none focus:ring-1 text-white border-white focus:ring-blue-400 focus:border-blue-400"
+      className={`bg-primary-dark rounded-xl w-1/3 h-10 mt-4 border-2 pl-2 focus:outline-none focus:ring-1 text-white border-white focus:ring-blue-400 focus:border-blue-400 ${props.additionalClass ?? ""} `}
       onChange={(event) => {
         callback(event.target.value);
       }}

--- a/client/src/pages/JoinTournament.tsx
+++ b/client/src/pages/JoinTournament.tsx
@@ -105,6 +105,7 @@ const JoinTournament = () => {
           placeholder={"6 DIGIT ROOM CODE"}
           disabled={loading}
           data-testid={"tournament-code-input"}
+          additionalClass={"large-input"}
         />
         <InputComponent
           value={playerName}
@@ -112,12 +113,14 @@ const JoinTournament = () => {
           placeholder={"NAME"}
           disabled={loading}
           data-testid={"player-name-input"}
+          additionalClass={"large-input"}
         />
 
         <FormButton
           text={"Join Game"}
           loading={loading}
           callback={joinTournament}
+          additionalClass={"large-btn"}
         />
       </div>
       {!status || status === "OK" ? null : (


### PR DESCRIPTION
Implementation:

- Added optional classname prop to btn and input
- Created class for large-btn and large-input, they have a max-width, and take up a greater percentage of screens below 700px
- Fixed button component styling having a set height can cause text overflow, so used padding instead