### PR TITLE
Feature: adaptive star / number display for duelling screens

### DIFF
--- a/client/src/components/lobby/HostSpectatorScreen.tsx
+++ b/client/src/components/lobby/HostSpectatorScreen.tsx
@@ -23,6 +23,7 @@ const HostSpectatorScreen = ({
   stopSpectating,
 }: PlayerScreenProps) => {
   const MATCH_COMPLETION_TIME = 4000;
+  const DEFAULT_DUELS_TO_WIN = 3;
   const [playerName] = useState("HOST");
 
   const [userPlayer, setUserPlayer] = useState<PlayerAttributes>(); // spectating player
@@ -32,6 +33,7 @@ const HostSpectatorScreen = ({
   const [matchType, setMatchType] = useState<MatchType>();
   const [isPlayerOne, setIsPlayerOne] = useState(false);
   const [duelTime, setDuelTime] = useState(15);
+  const [duelsToWin, setDuelsToWin] = useState(DEFAULT_DUELS_TO_WIN);
 
   function setPlayers(players: PlayerAttributes[]) {
     for (let i = 0; i < players.length; i++) {
@@ -67,10 +69,11 @@ const HostSpectatorScreen = ({
   }, [matchData]);
 
   useEffect(() => {
-    socket.on("MATCH_START", (players, matchType, duelTime) => {
+    socket.on("MATCH_START", (players, matchType, duelTime, numDuelsToWin) => {
       setPlayers(players);
       setMatchType(matchType);
       setDuelTime(duelTime);
+      setDuelsToWin(numDuelsToWin);
     });
 
     socket.on("MATCH_DATA", (players, winnerUserID) => {
@@ -165,6 +168,7 @@ const HostSpectatorScreen = ({
               userPlayer={userPlayer}
               opponent={opponent}
               isSpectator={true}
+              duelsToWin={duelsToWin}
             />
             // TODO probably only want to display during a match and not after a match
           )}

--- a/client/src/components/player-screen/match-overlay/PlayerAndSpectatorsInfo.tsx
+++ b/client/src/components/player-screen/match-overlay/PlayerAndSpectatorsInfo.tsx
@@ -7,13 +7,15 @@ type PlayerAndSpectatorsInfoProps = {
   userPlayer: PlayerAttributes;
   opponent: PlayerAttributes;
   isSpectator: boolean;
+  duelsToWin: number;
 };
 
 const PlayerAndSpectatorsInfo = ({
   userPlayer,
   opponent,
   isSpectator,
-}: PlayerAndSpectatorsInfoProps) => {
+  duelsToWin
+  }: PlayerAndSpectatorsInfoProps) => {
   return (
     <div>
       <div className="hidden">
@@ -23,6 +25,7 @@ const PlayerAndSpectatorsInfo = ({
         <StarsInfo
           playerName={opponent.name}
           score={opponent.score}
+          duelLimit={duelsToWin}
           isOpponent={true}
           isSpectator={isSpectator}
         />
@@ -35,6 +38,7 @@ const PlayerAndSpectatorsInfo = ({
         <StarsInfo
           playerName={userPlayer.name}
           score={userPlayer.score}
+          duelLimit={duelsToWin}
           isOpponent={false}
           isSpectator={isSpectator}
         />

--- a/client/src/components/player-screen/match-overlay/PlayerAndSpectatorsInfo.tsx
+++ b/client/src/components/player-screen/match-overlay/PlayerAndSpectatorsInfo.tsx
@@ -14,8 +14,8 @@ const PlayerAndSpectatorsInfo = ({
   userPlayer,
   opponent,
   isSpectator,
-  duelsToWin
-  }: PlayerAndSpectatorsInfoProps) => {
+  duelsToWin,
+}: PlayerAndSpectatorsInfoProps) => {
   return (
     <div>
       <div className="hidden">

--- a/client/src/components/player-screen/match-overlay/StarsInfo.tsx
+++ b/client/src/components/player-screen/match-overlay/StarsInfo.tsx
@@ -2,9 +2,46 @@ import filledStar from "../../../assets/misc/FilledStar.svg";
 import unfilledStar from "../../../assets/misc/UnfilledStar.svg";
 import eyeIcon from "../../../assets/misc/EyeIcon.svg";
 
+// type StarsInfoProps = {
+//   playerName: string;
+//   score: number;
+//   isOpponent: boolean;
+//   isSpectator: boolean;
+// };
+
+// const StarsInfo = ({
+//   playerName,
+//   score,
+//   isOpponent,
+//   isSpectator,
+// }: StarsInfoProps) => {
+//   return (
+//     <div
+//       className={
+//         "fixed text-white font-bold text-2xl px-4 rounded-xl pb-2 -m-4 z-0 shadow-[0_0_10px_4px_rgba(0,0,0,0.3)]" +
+//         ` ${isOpponent ? "top-8 right-8 bg-[#FF5959] " : `bottom-8 left-8 ${isSpectator ? "bg-spectator-bg" : "bg-green-bg"}`}`
+//       }
+//     >
+//       <p className="max-h-4 align-middle items-center inline-flex">
+//         {isSpectator && !isOpponent ? (
+//           <img src={eyeIcon} alt="Eye Icon" className="block mr-3" />
+//         ) : null}
+//         {playerName} <p className="md:hidden sm:block "> {`: ${score}`}</p>
+//       </p>
+//       <div className="mx-auto max-w-max inset-x-0 space-x-3 mt-1 scale-90 hidden sm:flex">
+//         <img src={score >= 1 ? filledStar : unfilledStar} />
+//         <img src={score >= 2 ? filledStar : unfilledStar} />
+//         <img src={score >= 3 ? filledStar : unfilledStar} />
+//       </div>
+//     </div>
+//   );
+// };
+
+// Updated StarsInfo
 type StarsInfoProps = {
   playerName: string;
   score: number;
+  duelLimit: number;
   isOpponent: boolean;
   isSpectator: boolean;
 };
@@ -12,6 +49,7 @@ type StarsInfoProps = {
 const StarsInfo = ({
   playerName,
   score,
+  duelLimit,
   isOpponent,
   isSpectator,
 }: StarsInfoProps) => {
@@ -26,12 +64,16 @@ const StarsInfo = ({
         {isSpectator && !isOpponent ? (
           <img src={eyeIcon} alt="Eye Icon" className="block mr-3" />
         ) : null}
-        {playerName} <p className="md:hidden sm:block "> {`: ${score}`}</p>
+        {playerName} <p className={`${duelLimit <= 5 ? 'md:hidden' : 'md:block'} sm:block`}> {`: ${score}`}</p>
       </p>
       <div className="mx-auto max-w-max inset-x-0 space-x-3 mt-1 scale-90 hidden sm:flex">
-        <img src={score >= 1 ? filledStar : unfilledStar} />
-        <img src={score >= 2 ? filledStar : unfilledStar} />
-        <img src={score >= 3 ? filledStar : unfilledStar} />
+        {
+          duelLimit <= 5 && Array.from(
+            { length: duelLimit }, (_, index) => (
+              <img key={index} src={`${index + 1 <= score ? filledStar : unfilledStar}`} />
+            )
+          )
+        }
       </div>
     </div>
   );

--- a/client/src/components/player-screen/match-overlay/StarsInfo.tsx
+++ b/client/src/components/player-screen/match-overlay/StarsInfo.tsx
@@ -2,42 +2,6 @@ import filledStar from "../../../assets/misc/FilledStar.svg";
 import unfilledStar from "../../../assets/misc/UnfilledStar.svg";
 import eyeIcon from "../../../assets/misc/EyeIcon.svg";
 
-// type StarsInfoProps = {
-//   playerName: string;
-//   score: number;
-//   isOpponent: boolean;
-//   isSpectator: boolean;
-// };
-
-// const StarsInfo = ({
-//   playerName,
-//   score,
-//   isOpponent,
-//   isSpectator,
-// }: StarsInfoProps) => {
-//   return (
-//     <div
-//       className={
-//         "fixed text-white font-bold text-2xl px-4 rounded-xl pb-2 -m-4 z-0 shadow-[0_0_10px_4px_rgba(0,0,0,0.3)]" +
-//         ` ${isOpponent ? "top-8 right-8 bg-[#FF5959] " : `bottom-8 left-8 ${isSpectator ? "bg-spectator-bg" : "bg-green-bg"}`}`
-//       }
-//     >
-//       <p className="max-h-4 align-middle items-center inline-flex">
-//         {isSpectator && !isOpponent ? (
-//           <img src={eyeIcon} alt="Eye Icon" className="block mr-3" />
-//         ) : null}
-//         {playerName} <p className="md:hidden sm:block "> {`: ${score}`}</p>
-//       </p>
-//       <div className="mx-auto max-w-max inset-x-0 space-x-3 mt-1 scale-90 hidden sm:flex">
-//         <img src={score >= 1 ? filledStar : unfilledStar} />
-//         <img src={score >= 2 ? filledStar : unfilledStar} />
-//         <img src={score >= 3 ? filledStar : unfilledStar} />
-//       </div>
-//     </div>
-//   );
-// };
-
-// Updated StarsInfo
 type StarsInfoProps = {
   playerName: string;
   score: number;

--- a/client/src/components/player-screen/match-overlay/StarsInfo.tsx
+++ b/client/src/components/player-screen/match-overlay/StarsInfo.tsx
@@ -28,16 +28,19 @@ const StarsInfo = ({
         {isSpectator && !isOpponent ? (
           <img src={eyeIcon} alt="Eye Icon" className="block mr-3" />
         ) : null}
-        {playerName} <p className={`${duelLimit <= 5 ? 'md:hidden' : 'md:block'} sm:block`}> {`: ${score}`}</p>
+        {playerName}
+        <p className={`${duelLimit <= 5 ? "md:hidden" : "md:block"} sm:block`}>
+          {`: ${score}`}
+        </p>
       </p>
       <div className="mx-auto max-w-max inset-x-0 space-x-3 mt-1 scale-90 hidden sm:flex">
-        {
-          duelLimit <= 5 && Array.from(
-            { length: duelLimit }, (_, index) => (
-              <img key={index} src={`${index + 1 <= score ? filledStar : unfilledStar}`} />
-            )
-          )
-        }
+        {duelLimit <= 5 &&
+          Array.from({ length: duelLimit }, (_, index) => (
+            <img
+              key={index}
+              src={`${index + 1 <= score ? filledStar : unfilledStar}`}
+            />
+          ))}
       </div>
     </div>
   );

--- a/client/src/pages/PlayerScreen.tsx
+++ b/client/src/pages/PlayerScreen.tsx
@@ -13,6 +13,7 @@ import { RPS } from "../components/rps/RPS.tsx";
 import DuelInProgressAnimation from "../components/player-screen/DuelInProgressAnimation.tsx";
 
 const DEFAULT_DUEL_TIME = 15; // seconds
+const DEFAULT_DUELS_TO_WIN = 3;
 
 const PlayerScreen = () => {
   const { loadedTournamentCode, loadedPlayerName } = useLoaderData() as {
@@ -31,6 +32,7 @@ const PlayerScreen = () => {
   const [matchType, setMatchType] = useState<MatchType>();
   const [isPlayerOne, setIsPlayerOne] = useState(false);
   const [duelTime, setDuelTime] = useState(DEFAULT_DUEL_TIME);
+  const [duelsToWin, setDuelsToWin] = useState(DEFAULT_DUELS_TO_WIN);
   const [showAnimation, setShowAnimation] = useState(false);
 
   function setPlayers(players: PlayerAttributes[]) {
@@ -71,11 +73,12 @@ const PlayerScreen = () => {
   }
 
   useEffect(() => {
-    socket.on("MATCH_START", (players, matchType, duelTime) => {
+    socket.on("MATCH_START", (players, matchType, duelTime, numDuelsToWin) => {
       setPlayers(players);
       setMatchType(matchType);
       setIsSpectator(getIsSpectator(players));
       setDuelTime(duelTime);
+      setDuelsToWin(numDuelsToWin);
       const storedMatchState = localStorage.getItem("matchStarted");
       if (matchType === "RPS" && storedMatchState !== "true") {
         // Only have RPS animation atm, dont show for PONG
@@ -183,6 +186,7 @@ const PlayerScreen = () => {
                 userPlayer={userPlayer}
                 opponent={opponent}
                 isSpectator={isSpectator}
+                duelsToWin={duelsToWin}
               />
             )}
             {content}

--- a/server/src/emitters/roundStartEmitter.ts
+++ b/server/src/emitters/roundStartEmitter.ts
@@ -17,6 +17,7 @@ export async function roundStartEmitter(
           match.players,
           match.type(),
           tournament.duelTime / 1000,
+          tournament.duelsToWin,
         );
       }
 
@@ -27,6 +28,7 @@ export async function roundStartEmitter(
           match.players,
           match.type(),
           tournament.duelTime / 1000,
+          tournament.duelsToWin,
         );
       }
     }

--- a/server/src/model/matches/pongMatch.ts
+++ b/server/src/model/matches/pongMatch.ts
@@ -76,6 +76,7 @@ export class PongMatch implements Match {
       this.players,
       this.type(),
       this.tournament.duelTime / 1000,
+      this.tournament.duelsToWin,
     );
 
     setTimeout(() => {

--- a/server/src/model/matches/rpsMatch.ts
+++ b/server/src/model/matches/rpsMatch.ts
@@ -214,6 +214,7 @@ export class RpsMatch implements Match {
       this.players,
       this.type(),
       tournament.duelTime / 1000,
+      tournament.duelsToWin,
     );
     // removing the player's previous powerups
     this.players[0].powerup = null;

--- a/server/src/utils/reconnectionHelper.ts
+++ b/server/src/utils/reconnectionHelper.ts
@@ -42,6 +42,7 @@ export async function reconnectionHandler(
                 match.players,
                 match.type(),
                 tournament.duelTime / 1000,
+                tournament.duelsToWin,
               );
 
               match.emitMatchState(io);

--- a/types/socket/events.ts
+++ b/types/socket/events.ts
@@ -64,7 +64,8 @@ interface ServerToPlayerEvents {
     MATCH_START: (
         players: PlayerAttributes[],
         matchType: MatchType,
-        duelTime: number
+        duelTime: number,
+        duelsToWin: number
     ) => void;
 
     MATCH_DATA: (


### PR DESCRIPTION
Implemented code so that the number of stars displayed accurately depicts the number of duels required for winning the round. 

If the number of duels to win is <= 5, then it will show the appropriate stars.
If the num. duels to win is >5 OR if the screen size is small, only the number of each players wins is displayed.

Involved modifying the "MATCH_START" event to send duelsToWin, along with modifying the appropriate pages that listened for the event. Also modified the StarsInfo and PlayerAndSpectatorsInfo pages to use the duelsToWin value to adjust display.